### PR TITLE
I've added checks on the controller endpoints for the correct `Accept…

### DIFF
--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/ErrorResponses.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apprenticeshiplevy.controllers
+
+import ErrorResponse.ErrorContentFormat
+import play.api.libs.json.Json.format
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Results
+import play.api.mvc.Results._
+import play.mvc.Http.Status._
+
+case class ResponseContents(code: String, message: String) {
+
+  def getStatus: Results.Status = code match {
+    case CODE_UNAUTHORIZED => Unauthorized
+    case CODE_INVALID_TAX_YEAR => BadRequest
+    case CODE_INVALID_EMP_REF => BadRequest
+    case CODE_BAD_REQUEST => BadRequest
+    case CODE_NOT_FOUND => NotFound
+    case CODE_INVALID_HEADER => NotAcceptable
+    case CODE_INTERNAL_SERVER_ERROR => InternalServerError
+    case CODE_NOT_IMPLEMENTED => NotImplemented
+    case CODE_SERVICE_UNAVAILABLE => ServiceUnavailable
+  }
+}
+
+case class ErrorResponse(httpStatusCode: Int, content: ResponseContents) extends Error {
+  lazy val JSON: JsValue = Json.toJson(content)(ErrorContentFormat)
+  lazy val ResponseContents = Json.stringify(JSON)
+  lazy val Result = Status(httpStatusCode)(JSON)
+}
+
+object ErrorResponse {
+  implicit val ErrorContentFormat = format[ResponseContents]
+
+  val ErrorUnauthorized = ErrorResponse(UNAUTHORIZED,
+    ResponseContents(CODE_UNAUTHORIZED, "Invalid Authentication information provided"))
+
+  val ErrorTaxYearInvalid = ErrorResponse(BAD_REQUEST,
+    ResponseContents(CODE_INVALID_TAX_YEAR,
+      "Tax Year must be of the form yyyy-yy and the year values must be consecutive. ex. 2012-13"))
+
+  val ErrorEmpRefInvalid = ErrorResponse(BAD_REQUEST,
+    ResponseContents(CODE_INVALID_EMP_REF, "EmpRef requires two identifiers separated by a slash"))
+
+  val ErrorGenericBadRequest = ErrorResponse(BAD_REQUEST,
+    ResponseContents(CODE_BAD_REQUEST, "Bad Request"))
+
+  val ErrorNotFound = ErrorResponse(NOT_FOUND, ResponseContents("NOT_FOUND", "Resource was not found"))
+
+  val ErrorAcceptHeaderInvalid = ErrorResponse(NOT_ACCEPTABLE,
+    ResponseContents(CODE_INVALID_HEADER, "The accept header is missing or invalid"))
+
+  val ErrorInternalServerError = ErrorResponse(INTERNAL_SERVER_ERROR,
+    ResponseContents(CODE_INTERNAL_SERVER_ERROR, "Internal server error"))
+
+  val ErrorServiceUnavailable = ErrorResponse(SERVICE_UNAVAILABLE,
+    ResponseContents(CODE_SERVICE_UNAVAILABLE, "Could not connect to DES endpoint"))
+
+  val ErrorNotImplemented = ErrorResponse(NOT_IMPLEMENTED,
+    ResponseContents(CODE_SERVICE_UNAVAILABLE, "Service endpoint is not implemented"))
+}

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsController.scala
@@ -16,10 +16,9 @@
 
 package uk.gov.hmrc.apprenticeshiplevy.controllers
 
-import play.api.mvc.Action
-import uk.gov.hmrc.play.microservice.controller.BaseController
 import uk.gov.hmrc.apprenticeshiplevy.controllers.ErrorResponse.ErrorNotImplemented
 import uk.gov.hmrc.apprenticeshiplevy.controllers.actions.HeaderValidatorAction
+import uk.gov.hmrc.play.microservice.controller.BaseController
 
 trait FractionsController extends BaseController {
   def fractions(empref: String, months: Option[Int]) = HeaderValidatorAction {

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsController.scala
@@ -18,9 +18,13 @@ package uk.gov.hmrc.apprenticeshiplevy.controllers
 
 import play.api.mvc.Action
 import uk.gov.hmrc.play.microservice.controller.BaseController
+import uk.gov.hmrc.apprenticeshiplevy.controllers.ErrorResponse.ErrorNotImplemented
+import uk.gov.hmrc.apprenticeshiplevy.controllers.actions.HeaderValidatorAction
 
 trait FractionsController extends BaseController {
-  def fractions(empref: String, months: Option[Int]) = Action { NotImplemented }
+  def fractions(empref: String, months: Option[Int]) = HeaderValidatorAction {
+    ErrorNotImplemented.Result
+  }
 }
 
 object FractionsController extends FractionsController

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/LevyDeclarationController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/LevyDeclarationController.scala
@@ -18,9 +18,13 @@ package uk.gov.hmrc.apprenticeshiplevy.controllers
 
 import play.api.mvc.Action
 import uk.gov.hmrc.play.microservice.controller.BaseController
+import uk.gov.hmrc.apprenticeshiplevy.controllers.ErrorResponse.ErrorNotImplemented
+import uk.gov.hmrc.apprenticeshiplevy.controllers.actions.HeaderValidatorAction
 
 trait LevyDeclarationController extends BaseController {
-  def declarations(empref: String, months: Option[Int]) = Action { NotImplemented }
+  def declarations(empref: String, months: Option[Int]) = HeaderValidatorAction {
+    ErrorNotImplemented.Result
+  }
 }
 
 object LevyDeclarationController extends LevyDeclarationController

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/actions/HeaderValidatorAction.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/actions/HeaderValidatorAction.scala
@@ -26,7 +26,7 @@ object HeaderValidatorAction extends ActionBuilder[Request] {
 
   private val ExpectedAcceptHeader = "application/vnd.hmrc.1.0+json"
 
-  def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
+  override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
     request.headers.get(ACCEPT).contains(ExpectedAcceptHeader) match {
       case true => block(request)
       case false => Future.successful(ErrorAcceptHeaderInvalid.Result)

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/actions/HeaderValidatorAction.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/actions/HeaderValidatorAction.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apprenticeshiplevy.controllers.actions
+
+import play.api.mvc.{ActionBuilder, Request, Result}
+import play.mvc.Http.HeaderNames.ACCEPT
+import uk.gov.hmrc.apprenticeshiplevy.controllers.ErrorResponse.ErrorAcceptHeaderInvalid
+import scala.concurrent.Future
+
+
+object HeaderValidatorAction extends ActionBuilder[Request] {
+
+  private val ExpectedAcceptHeader = "application/vnd.hmrc.1.0+json"
+
+  def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]) = {
+    request.headers.get(ACCEPT).contains(ExpectedAcceptHeader) match {
+      case true => block(request)
+      case false => Future.successful(ErrorAcceptHeaderInvalid.Result)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/package.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/package.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.apprenticeshiplevy
+
+import play.api.mvc.Results._
+
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+  * Created by jim on 11/05/2016.
+  */
+package object controllers {
+  val CODE_UNAUTHORIZED = "UNAUTHORIZED"
+  val CODE_INVALID_TAX_YEAR = "ERROR_TAX_YEAR_INVALID"
+  val CODE_INVALID_EMP_REF = "ERROR_EMP_REF_INVALID"
+  val CODE_BAD_REQUEST = "BAD_REQUEST"
+  val CODE_NOT_FOUND = "NOT_FOUND"
+  val CODE_INVALID_HEADER = "ACCEPT_HEADER_INVALID"
+  val CODE_INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"
+  val CODE_NOT_IMPLEMENTED = "NOT_IMPLEMENTED"
+  val CODE_SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE"
+}

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/package.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/package.scala
@@ -16,28 +16,6 @@
 
 package uk.gov.hmrc.apprenticeshiplevy
 
-import play.api.mvc.Results._
-
-/*
- * Copyright 2016 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
-/**
-  * Created by jim on 11/05/2016.
-  */
 package object controllers {
   val CODE_UNAUTHORIZED = "UNAUTHORIZED"
   val CODE_INVALID_TAX_YEAR = "ERROR_TAX_YEAR_INVALID"

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/sandbox/SandboxFractionsController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/sandbox/SandboxFractionsController.scala
@@ -21,9 +21,10 @@ import play.api.libs.json.Json
 import play.api.mvc.Action
 import uk.gov.hmrc.apprenticeshiplevy.connectors.ITMPConnector
 import uk.gov.hmrc.apprenticeshiplevy.controllers.FractionsController
+import uk.gov.hmrc.apprenticeshiplevy.controllers.actions.HeaderValidatorAction
 
 trait SandboxFractionsController extends FractionsController {
-  override def fractions(empref: String, months: Option[Int]) = Action.async { implicit request =>
+  override def fractions(empref: String, months: Option[Int]) = HeaderValidatorAction.async { implicit request =>
     ITMPConnector.fractions(empref, months).map(fs => Ok(Json.toJson(fs)))
   }
 }

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/sandbox/SandboxLevyDeclarationController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/sandbox/SandboxLevyDeclarationController.scala
@@ -21,10 +21,11 @@ import play.api.libs.json.Json
 import play.api.mvc.Action
 import uk.gov.hmrc.apprenticeshiplevy.connectors.ETMPConnector
 import uk.gov.hmrc.apprenticeshiplevy.controllers.LevyDeclarationController
+import uk.gov.hmrc.apprenticeshiplevy.controllers.actions.HeaderValidatorAction
 
 trait SandboxLevyDeclarationController extends LevyDeclarationController {
 
-  override def declarations(empref: String, months: Option[Int]) = Action.async { implicit request =>
+  override def declarations(empref: String, months: Option[Int]) = HeaderValidatorAction.async { implicit request =>
     ETMPConnector.declarations(empref, months)
       .map(ds => Ok(Json.toJson(ds)))
   }

--- a/test/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsControllerSpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.play.test.UnitSpec
 class FractionsControllerSpec extends UnitSpec with ScalaFutures {
   "getting the fractions" should {
     "return an HTTP Not Implemented response" in {
-      val response = FractionsController.fractions("empref", None)(FakeRequest()).futureValue
+      val response = FractionsController.fractions("empref", None)(FakeRequest().withHeaders(("Accept" -> "application/vnd.hmrc.1.0+json"))).futureValue
       response.header.status shouldBe NOT_IMPLEMENTED
     }
   }

--- a/test/uk/gov/hmrc/apprenticeshiplevy/controllers/LevyDeclarationControllerSpec.scala
+++ b/test/uk/gov/hmrc/apprenticeshiplevy/controllers/LevyDeclarationControllerSpec.scala
@@ -21,12 +21,11 @@ import play.api.http.Status.NOT_IMPLEMENTED
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.UnitSpec
 
-
 class LevyDeclarationControllerSpec extends UnitSpec with ScalaFutures {
 
   "getting the levy declarations" should {
     "return an HTTP Not Implemented response" in {
-      val response = LevyDeclarationController.declarations("empref", None)(FakeRequest()).futureValue
+      val response = LevyDeclarationController.declarations("empref", None)(FakeRequest().withHeaders("Accept" -> "application/vnd.hmrc.1.0+json")).futureValue
       response.header.status shouldBe NOT_IMPLEMENTED
     }
   }


### PR DESCRIPTION
…` header with a value of `application/vnd.hmrc.1.0+json`. I've also pulled in some code to provide normalised error responses.