### PR TITLE
[DC] I've pulled the implementation of the declarations and fractions…

### DIFF
--- a/app/uk/gov/hmrc/apprenticeshiplevy/config/AppContext.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/config/AppContext.scala
@@ -37,6 +37,8 @@ object AppContext extends ServicesConfig {
       }
 
   lazy val etmpUrl = baseUrl("etmp")
+  lazy val stubEtmpUrl = baseUrl("stub-etmp")
 
   lazy val itmpUrl = baseUrl("itmp")
+  lazy val stubItmpUrl = baseUrl("stub-itmp")
 }

--- a/app/uk/gov/hmrc/apprenticeshiplevy/connectors/ETMPConnector.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/connectors/ETMPConnector.scala
@@ -62,3 +62,9 @@ object ETMPConnector extends ETMPConnector {
 
   override def httpGet = WSHttp
 }
+
+object StubETMPConnector extends ETMPConnector {
+  override def etmpBaseUrl = AppContext.stubEtmpUrl
+
+  override def httpGet = WSHttp
+}

--- a/app/uk/gov/hmrc/apprenticeshiplevy/connectors/ITMPConnector.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/connectors/ITMPConnector.scala
@@ -46,3 +46,9 @@ object ITMPConnector extends ITMPConnector {
 
   override def httpGet = WSHttp
 }
+
+object StubITMPConnector extends ITMPConnector {
+  override def itmpBaseUrl = AppContext.stubEtmpUrl
+
+  override def httpGet = WSHttp
+}

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/ApiController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/ApiController.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.apprenticeshiplevy.controllers
 
 import play.api.libs.json.Json
 import play.api.mvc.Result
-import play.api.mvc.Results._
 import uk.gov.hmrc.api.controllers.{ErrorResponse, HeaderValidator}
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
@@ -28,5 +27,5 @@ trait ApiController extends BaseController with HeaderValidator {
     def result: Result = Status(er.httpStatusCode)(Json.toJson(er))
   }
 
-  def withValidAcceptHeader = validateAccept(acceptHeaderValidationRules)
+  val withValidAcceptHeader = validateAccept(acceptHeaderValidationRules)
 }

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsController.scala
@@ -16,12 +16,15 @@
 
 package uk.gov.hmrc.apprenticeshiplevy.controllers
 
-import uk.gov.hmrc.apprenticeshiplevy.controllers.ErrorResponses.ErrorNotImplemented
+import play.api.libs.json.Json
+import uk.gov.hmrc.apprenticeshiplevy.connectors.ITMPConnector
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-trait FractionsController extends ApiController {
-  def fractions(empref: String, months: Option[Int]) = withValidAcceptHeader {
-    ErrorNotImplemented.result
+trait FractionsController {
+  self: ApiController =>
+  def itmpConnector: ITMPConnector
+
+  def fractions(empref: String, months: Option[Int]) = withValidAcceptHeader.async { implicit request =>
+    ITMPConnector.fractions(empref, months).map(fs => Ok(Json.toJson(fs)))
   }
 }
-
-object FractionsController extends FractionsController

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/LevyDeclarationController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/LevyDeclarationController.scala
@@ -16,12 +16,18 @@
 
 package uk.gov.hmrc.apprenticeshiplevy.controllers
 
-import uk.gov.hmrc.apprenticeshiplevy.controllers.ErrorResponses.ErrorNotImplemented
+import play.api.libs.json.Json
+import uk.gov.hmrc.apprenticeshiplevy.connectors.ETMPConnector
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
-trait LevyDeclarationController extends  ApiController {
-  def declarations(empref: String, months: Option[Int]) = withValidAcceptHeader {
-    ErrorNotImplemented.result
+trait LevyDeclarationController {
+  self: ApiController =>
+  def etmpConnector: ETMPConnector
+
+  def declarations(empref: String, months: Option[Int]) = withValidAcceptHeader.async { implicit request =>
+    ETMPConnector.declarations(empref, months)
+      .map(ds => Ok(Json.toJson(ds)))
   }
 }
 
-object LevyDeclarationController extends LevyDeclarationController
+

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/live/LiveFractionsController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/live/LiveFractionsController.scala
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.apprenticeshiplevy.controllers.sandbox
+package uk.gov.hmrc.apprenticeshiplevy.controllers.live
 
-import uk.gov.hmrc.apprenticeshiplevy.connectors.StubETMPConnector
-import uk.gov.hmrc.apprenticeshiplevy.controllers.{ApiController, LevyDeclarationController}
+import play.api.mvc.{Action, AnyContent}
+import uk.gov.hmrc.apprenticeshiplevy.controllers.{ApiController, FractionsController}
 
-object SandboxLevyDeclarationController extends ApiController with LevyDeclarationController {
-  override def etmpConnector = StubETMPConnector
+
+object LiveFractionsController extends ApiController with FractionsController {
+  override def itmpConnector = ???
+
+  /**
+    * TODO: Remove this overridden method to enable the main implementation from the trait
+    */
+  override def fractions(empref: String, months: Option[Int]): Action[AnyContent] = withValidAcceptHeader {
+    NotImplemented
+  }
 }

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/live/LiveLevyDeclarationController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/live/LiveLevyDeclarationController.scala
@@ -14,11 +14,18 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.apprenticeshiplevy.controllers.sandbox
+package uk.gov.hmrc.apprenticeshiplevy.controllers.live
 
-import uk.gov.hmrc.apprenticeshiplevy.connectors.StubETMPConnector
+import uk.gov.hmrc.apprenticeshiplevy.connectors.ETMPConnector
 import uk.gov.hmrc.apprenticeshiplevy.controllers.{ApiController, LevyDeclarationController}
 
-object SandboxLevyDeclarationController extends ApiController with LevyDeclarationController {
-  override def etmpConnector = StubETMPConnector
+object LiveLevyDeclarationController extends ApiController with LevyDeclarationController {
+  override def etmpConnector: ETMPConnector = ???
+
+  /**
+    * TODO: Remove this overridden method to enable the main implementation from the trait
+    */
+  override def declarations(empref: String, months: Option[Int]) = withValidAcceptHeader {
+    NotImplemented
+  }
 }

--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/sandbox/SandboxFractionsController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/sandbox/SandboxFractionsController.scala
@@ -16,15 +16,9 @@
 
 package uk.gov.hmrc.apprenticeshiplevy.controllers.sandbox
 
-import play.api.libs.json.Json
-import uk.gov.hmrc.apprenticeshiplevy.connectors.ITMPConnector
-import uk.gov.hmrc.apprenticeshiplevy.controllers.FractionsController
-import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import uk.gov.hmrc.apprenticeshiplevy.connectors.StubITMPConnector
+import uk.gov.hmrc.apprenticeshiplevy.controllers.{ApiController, FractionsController}
 
-trait SandboxFractionsController extends FractionsController {
-  override def fractions(empref: String, months: Option[Int]) = withValidAcceptHeader.async { implicit request =>
-    ITMPConnector.fractions(empref, months).map(fs => Ok(Json.toJson(fs)))
-  }
+object SandboxFractionsController extends ApiController with FractionsController {
+  override def itmpConnector = StubITMPConnector
 }
-
-object SandboxFractionsController extends SandboxFractionsController

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 # microservice specific routes
 
-GET        /epaye/:empref/declarations                  uk.gov.hmrc.apprenticeshiplevy.controllers.LevyDeclarationController.declarations(empref:String, months:Option[Int])
-GET        /epaye/:empref/fractions                     uk.gov.hmrc.apprenticeshiplevy.controllers.FractionsController.fractions(empref:String, months:Option[Int])
+GET        /epaye/:empref/declarations                  uk.gov.hmrc.apprenticeshiplevy.controllers.live.LiveLevyDeclarationController.declarations(empref:String, months:Option[Int])
+GET        /epaye/:empref/fractions                     uk.gov.hmrc.apprenticeshiplevy.controllers.live.LiveFractionsController.fractions(empref:String, months:Option[Int])
 GET        /user-accounts                               uk.gov.hmrc.apprenticeshiplevy.controllers.UserInfoController.userAccounts
 GET        /api/definition                              controllers.Assets.at(path="/public/api", file = "definition.json")
 GET        /api/documentation/:version/:endpoint        uk.gov.hmrc.apprenticeshiplevy.controllers.DocumentationController.documentation(version, endpoint)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -82,7 +82,13 @@ controllers {
     needsAuditing = false
   }
 
-  uk.gov.hmrc.apprenticeshiplevy.controllers.LevyDeclarationController = {
+  uk.gov.hmrc.apprenticeshiplevy.controllers.live.LiveLevyDeclarationController = {
+    needsAuth = false
+    needsLogging = true
+    needsAuditing = true
+  }
+
+  uk.gov.hmrc.apprenticeshiplevy.controllers.live.LiveFractionsController = {
     needsAuth = false
     needsLogging = true
     needsAuditing = true
@@ -108,6 +114,13 @@ controllers {
 
   # sandboxes
   uk.gov.hmrc.apprenticeshiplevy.controllers.sandbox.SandboxLevyDeclarationController = {
+    needsAuth = false
+    needsLogging = true
+    needsAuditing = true
+  }
+
+  # sandboxes
+  uk.gov.hmrc.apprenticeshiplevy.controllers.sandbox.SandboxFractionsController = {
     needsAuth = false
     needsLogging = true
     needsAuditing = true
@@ -178,6 +191,16 @@ microservice {
       host = service-locator.service
       port = 80
       enabled = false
+    }
+
+    stub-etmp {
+      host = localhost
+      port = 9475
+    }
+
+    stub-itmp {
+      host = localhost
+      port = 9475
     }
 
     etmp {

--- a/test/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionsControllerSpec.scala
@@ -17,20 +17,21 @@
 package uk.gov.hmrc.apprenticeshiplevy.controllers
 
 import org.scalatest.concurrent.ScalaFutures
-import play.api.http.Status._
 import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.apprenticeshiplevy.controllers.live.LiveFractionsController
 import uk.gov.hmrc.play.test.UnitSpec
 
 class FractionsControllerSpec extends UnitSpec with ScalaFutures {
   "getting the fractions" should {
 
     "return a Not Acceptable response if the Accept header is not correctly set" in {
-      val response = FractionsController.fractions("empref", None)(FakeRequest()).futureValue
+      val response = LiveFractionsController.fractions("empref", None)(FakeRequest()).futureValue
       response.header.status shouldBe NOT_ACCEPTABLE
     }
 
     "return an HTTP Not Implemented response" in {
-      val response = FractionsController.fractions("empref", None)(FakeRequest().withHeaders("Accept" -> "application/vnd.hmrc.1.0+json")).futureValue
+      val response = LiveFractionsController.fractions("empref", None)(FakeRequest().withHeaders("Accept" -> "application/vnd.hmrc.1.0+json")).futureValue
       response.header.status shouldBe NOT_IMPLEMENTED
     }
   }

--- a/test/uk/gov/hmrc/apprenticeshiplevy/controllers/LevyDeclarationControllerSpec.scala
+++ b/test/uk/gov/hmrc/apprenticeshiplevy/controllers/LevyDeclarationControllerSpec.scala
@@ -17,20 +17,21 @@
 package uk.gov.hmrc.apprenticeshiplevy.controllers
 
 import org.scalatest.concurrent.ScalaFutures
-import play.api.http.Status._
 import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.apprenticeshiplevy.controllers.live.LiveLevyDeclarationController
 import uk.gov.hmrc.play.test.UnitSpec
 
 class LevyDeclarationControllerSpec extends UnitSpec with ScalaFutures {
 
   "getting the levy declarations" should {
     "return a Not Acceptable response if the Accept header is not correctly set" in {
-      val response = LevyDeclarationController.declarations("empref", None)(FakeRequest()).futureValue
+      val response = LiveLevyDeclarationController.declarations("empref", None)(FakeRequest()).futureValue
       response.header.status shouldBe NOT_ACCEPTABLE
     }
 
     "return an HTTP Not Implemented response" in {
-      val response = LevyDeclarationController.declarations("empref", None)(FakeRequest().withHeaders("Accept" -> "application/vnd.hmrc.1.0+json")).futureValue
+      val response = LiveLevyDeclarationController.declarations("empref", None)(FakeRequest().withHeaders("Accept" -> "application/vnd.hmrc.1.0+json")).futureValue
       response.header.status shouldBe NOT_IMPLEMENTED
     }
   }


### PR DESCRIPTION
… controller methods up into the respective traits. The traits define abstract methods to get their connectors. I've moved the objects that make up the live implementations into a `controllers.live` sub-package and overridden the controller methods to return `NotImplemented`.

The sandboxes look for stub connector definitions in the conf file, whilst the live controllers currently don't provide connectors as they should always return `NotImplemented` in any case.

All of this is to unify the way the controllers work so that we can build the implementations through experimentation with the sandboxes and hopefully ensure they'll behave identically with live backend services.