### PR TITLE
APIS-869: Fixing broken integration tests for RAML includes where served from non-local servers.

### DIFF
--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -48,7 +48,7 @@
     <logger name="com.google.inject" level="OFF"/>
     <logger name="org" level="OFF"/>
 
-    <logger name="application" level="DEBUG"/>
+    <logger name="application" level="OFF"/>
 
     <logger name="test-config" level="OFF"/>
 
@@ -58,7 +58,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="WARN">
+    <root level="OFF">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/it/uk/gov/hmrc/apprenticeshiplevy/DocumentationEndpointISpec.scala
+++ b/it/uk/gov/hmrc/apprenticeshiplevy/DocumentationEndpointISpec.scala
@@ -48,7 +48,7 @@ class DocumentationEndpointISpec extends WiremockFunSpec with ConfiguredServer  
         }
 
         val definitionFile = new File(s"./public/api/conf/$version/application.raml")
-        val includes = Source.fromFile(definitionFile).getLines.filter(_.contains("!include")).map((line)=>line.substring(line.indexOf("!include "))).toList
+        val includes = Source.fromFile(definitionFile).getLines.filter(_.contains("!include")).map((line)=>line.substring(line.indexOf("!include "))).toList.filterNot(_.matches(".*(errors|versioning).md"))
         includes.foreach { case (include) =>
           it (s"and serve file for $include") {
             // set up


### PR DESCRIPTION
Decreased logging