### PR TITLE
DDCNLS-954: (UNDO BRANCH) removing handler for OVERRIDE_EMPREF

### DIFF
--- a/app/uk/gov/hmrc/apprenticeshiplevy/controllers/ApiController.scala
+++ b/app/uk/gov/hmrc/apprenticeshiplevy/controllers/ApiController.scala
@@ -46,11 +46,7 @@ trait ApiController extends BaseController with HeaderValidator {
     val clientId = headersMap.getOrElse("X-Client-ID","Unknown caller")
     val user = headersMap.getOrElse("X-Client-Authorization-Token","Unknown caller")
 
-    play.api.Logger.info(s"""Creating header carrier with ${rh} and headers are: ${headersMap.mkString(" ")}""")
-    headersMap.get("OVERRIDE_EMPREF") match {
-      case Some(empref) => hc.copy(extraHeaders = Seq(("X-Client-ID",clientId),("X-Client-Authorization-Token",user),("OVERRIDE_EMPREF",empref)) ++ hc.extraHeaders)
-      case _ => hc.copy(extraHeaders = Seq(("X-Client-ID",clientId),("X-Client-Authorization-Token",user)) ++ hc.extraHeaders)
-    }
+    hc.copy(extraHeaders = Seq(("X-Client-ID",clientId),("X-Client-Authorization-Token",user)) ++ hc.extraHeaders)
   }
 
   def selfLink(url: String): HalLink = HalLink("self", url)

--- a/test/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionCalculationDateControllerSpec.scala
+++ b/test/uk/gov/hmrc/apprenticeshiplevy/controllers/FractionCalculationDateControllerSpec.scala
@@ -97,41 +97,6 @@ class FractionCalculationDateControllerSpec extends UnitSpec with MockitoSugar {
       actualHeaderCarrier.extraHeaders shouldBe List(("X-Client-ID","Unknown caller"),("X-Client-Authorization-Token","Unknown caller"),("Environment","clone"))
     }
 
-    "forward OVERRIDE_EMPREF header when supplied" in {
-      // set up
-      val stubHttpGet = mock[HttpGet]
-      val headerCarrierCaptor = ArgumentCaptor.forClass(classOf[HeaderCarrier])
-      when(stubHttpGet.GET[FractionCalculationDate](anyString())(any(), headerCarrierCaptor.capture()))
-           .thenReturn(Future.successful(FractionCalculationDate(new LocalDate(2016,11,3))))
-      val controller = new FractionsCalculationDateController() with DesController {
-        def desConnector: DesConnector = new DesConnector() {
-          def baseUrl: String = "http://a.guide.to.nowhere/"
-          def httpGet: HttpGet = stubHttpGet
-          protected def auditConnector: Option[AuditConnector] = None
-        }
-        override protected def defaultDESEnvironment: String = "clone"
-
-        override protected def defaultDESToken: String = "ABC"
-      }
-
-      // test
-      val response: Future[Result] = controller.fractionCalculationDate()(FakeRequest().withHeaders("ACCEPT"->"application/vnd.hmrc.1.0+json",
-                                                                                                    "Authorization"->"Bearer dsfda9080",
-                                                                                                    "Environment"->"clone",
-                                                                                                    "OVERRIDE_EMPREF" -> "THIS_IS_AN_EMP_REF"))
-
-      // check
-      val actualHeaderCarrier = headerCarrierCaptor.getValue
-      // this value is different from authorization header passed in above because
-      // DES authorization bearer token is different from user/client bearer token
-      val expectedHeaderCarrier = HeaderCarrier(Some(Authorization("Bearer ABC")))
-      actualHeaderCarrier.authorization shouldBe expectedHeaderCarrier.authorization
-      actualHeaderCarrier.extraHeaders shouldBe List(("X-Client-ID","Unknown caller"),
-                                                     ("X-Client-Authorization-Token","Unknown caller"),
-                                                     ("OVERRIDE_EMPREF","THIS_IS_AN_EMP_REF"),
-                                                     ("Environment","clone"))
-    }
-
     "recover from exceptions" in {
       // set up
       val stubHttpGet = mock[HttpGet]


### PR DESCRIPTION
OVERRIDE_EMPREF request header is not support in anything but the sandbox test data controller.
